### PR TITLE
Fixed: `allowedPattern` doesn't work when input is done through

### DIFF
--- a/dw-input.js
+++ b/dw-input.js
@@ -503,6 +503,7 @@ export class DwInput extends DwFormElement(LitElement) {
         .maxLength="${this.maxLength}"
         ?charCounter="${this.charCounter}"
         @keypress="${this._preventInvalidInput}"
+        @paste="${this._preventInvalidInput}"
         @keydown="${this._onKeyDown}"
         @input="${this._onInput}"
         @blur="${this._onInputBlur}"


### PR DESCRIPTION
copy/paste.